### PR TITLE
cicd(Argo): add opensearch override for fullname

### DIFF
--- a/beta/pool/values.yaml
+++ b/beta/pool/values.yaml
@@ -42,3 +42,6 @@ postgres:
   auth:
     postgresPassword: <path:bpdm/data/beta/pool/postgresql#postgres-password>
     password: <path:bpdm/data/beta/pool/postgresql#password>
+
+opensearch:
+  fullnameOverride: pool-beta-opensearch

--- a/dev/pool/values.yaml
+++ b/dev/pool/values.yaml
@@ -51,3 +51,6 @@ postgres:
   auth:
     postgresPassword: <path:bpdm/data/dev/pool/postgresql#postgres-password>
     password: <path:bpdm/data/dev/pool/postgresql#password>
+
+opensearch:
+  fullnameOverride: pool-dev-opensearch

--- a/int/pool/values.yaml
+++ b/int/pool/values.yaml
@@ -48,3 +48,6 @@ postgres:
   auth:
     postgresPassword: <path:bpdm/data/int/pool/postgresql#postgres-password>
     password: <path:bpdm/data/int/pool/postgresql#password>
+
+opensearch:
+  fullnameOverride: pool-int-opensearch

--- a/pen/pool/values.yaml
+++ b/pen/pool/values.yaml
@@ -42,3 +42,6 @@ postgres:
   auth:
     postgresPassword: <path:bpdm/data/pen-dev/pool/postgresql#postgres-password>
     password: <path:bpdm/data/pen-dev/pool/postgresql#password>
+
+opensearch:
+  fullnameOverride: pool-pen-opensearch


### PR DESCRIPTION
* makes it possible to deploy several opensearch instances in the same namespace