### PR TITLE
doc(int):increased EDC Chart connector version to 0.5.2

### DIFF
--- a/int/edc/chart/Chart.yaml
+++ b/int/edc/chart/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: 0.0.2
 dependencies:
   - name: tractusx-connector
     alias: txdc
-    version: 0.5.2
+    version: 0.5.3
     repository: https://eclipse-tractusx.github.io/charts/dev
   - name: opensearch
     version: 2.4.0

--- a/int/edc/chart/Chart.yaml
+++ b/int/edc/chart/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: edc
 description: A Helm chart for deploying an EDC for the BPDM environment
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.0.2
 dependencies:
   - name: tractusx-connector
     alias: txdc
-    version: 0.5.1
+    version: 0.5.2
     repository: https://eclipse-tractusx.github.io/charts/dev
   - name: opensearch
     version: 2.4.0


### PR DESCRIPTION
In this pull request, updating EDC chart connector version from 0.5.1 to 0.5.2